### PR TITLE
Restore frontend changes after merge fix with dev — canvas save/load,…

### DIFF
--- a/frontend/src/components/LayoutRenderer.jsx
+++ b/frontend/src/components/LayoutRenderer.jsx
@@ -2,17 +2,8 @@ import Section from "./Section";
 
 // ===== LayoutRenderer — renders sections according to the selected layout =====
 
-function LayoutRenderer({ layout, slots, selectedSectionId, onSelectSection, rows, cols, ads}) {
+function LayoutRenderer({ layout, slots, selectedSectionId, onSelectSection, rows, cols, gridSlots }) {
   const getSlotKey = (slot) => slot.id ?? `${slot.rowPos}-${slot.colPos}`;
-//   const renderSection = (slots) => (
-//     <Section
-//       key={getSlotKey(slots)}
-//       section={slots}
-//       slotKey={getSlotKey(slots)}
-//       isSelected={slots.dummyKey === selectedSectionId}
-//       onSelect={onSelectSection}
-//     />
-//   );
 
   return (
       <div
@@ -22,15 +13,24 @@ function LayoutRenderer({ layout, slots, selectedSectionId, onSelectSection, row
             gridTemplateRows: `repeat(${rows}, 1fr)`,
           }}
         >
-          {slots.map((slot) => (
-            <Section
-              key={getSlotKey(slot)}
-              section={slot}
-              slotKey={getSlotKey(slot)}
-              isSelected={getSlotKey(slot) === selectedSectionId}
-              onSelect={onSelectSection}
-            />
-          ))}
+          {slots.map((slot, index) => {
+            const gridInfo = gridSlots[index];
+            const gridStyle = gridInfo ? {
+              gridColumn: `${gridInfo.colPos} / span ${gridInfo.colSpan}`,
+              gridRow: `${gridInfo.rowPos} / span ${gridInfo.rowSpan}`,
+            } : {};
+
+            return (
+              <Section
+                key={getSlotKey(slot)}
+                section={slot}
+                slotKey={getSlotKey(slot)}
+                isSelected={getSlotKey(slot) === selectedSectionId}
+                onSelect={onSelectSection}
+                gridStyle={gridStyle}
+              />
+            );
+          })}
       </div>
     );
 

--- a/frontend/src/components/Section.jsx
+++ b/frontend/src/components/Section.jsx
@@ -9,7 +9,7 @@ const SLIDESHOW_IMAGES = [
   "https://placehold.co/400x200/dcfce7/22c55e?text=Slide+3",
 ];
 
-function Section({ section, isSelected, onSelect, slotKey }) {
+function Section({ section, isSelected, onSelect, slotKey, gridStyle = {} }) {
   const sectionRef = useRef(null);
   const [flexPercent, setFlexPercent] = useState(null);
 
@@ -79,8 +79,8 @@ function Section({ section, isSelected, onSelect, slotKey }) {
   }, []);
 
   const inlineStyle = flexPercent != null
-    ? { flex: `0 0 ${flexPercent}%`, overflow: "hidden" }
-    : { overflow: "hidden" };
+    ? { flex: `0 0 ${flexPercent}%`, overflow: "hidden", ...gridStyle }
+    : { overflow: "hidden", ...gridStyle };
 
   return (
     <div

--- a/frontend/src/components/Toolbar.jsx
+++ b/frontend/src/components/Toolbar.jsx
@@ -1,43 +1,36 @@
-// ===== Toolbar — top bar with editor actions =====
-
 const LAYOUTS = ["single", "two-columns", "header-two-columns", "grid", "right-column", "bottom-row", "six-section-grid"];
 
-function Toolbar({ currentLayout, onAddSlide, onChangeLayout, onPreview, onLogout,
-                                             onAddRow, onAddColumn, onRemoveRow, onRemoveColumn, onSave }) {
+function Toolbar({ currentLayout, onAddSlide, onChangeLayout, onPreview, onGoToLayouts, onSave, saveStatus }) {
   return (
     <div className="toolbar">
       <span className="toolbar-title">Digital Signage Editor</span>
 
-      {/* Add a new slide */}
-{/*       <button onClick={onAddSlide}>+ Add Slide</button> */}
-      <button onClick={onRemoveColumn}>-</button>
-      <span>Column</span>
-      <button onClick={onAddColumn}>+</button>
+      <button onClick={onAddSlide}>+ Add Slide</button>
 
-      <button onClick={onRemoveRow}>-</button>
-      <span>Row</span>
-      <button onClick={onAddRow}>+</button>
+      <select
+        value={currentLayout}
+        onChange={(e) => onChangeLayout(e.target.value)}
+      >
+        {LAYOUTS.map((layout) => (
+          <option key={layout} value={layout}>
+            {layout}
+          </option>
+        ))}
+      </select>
 
-      <button onClick={onSave}>Save Layout</button>
-
-      {/* Layout selector */}
-{/*       <select */}
-{/*         value={currentLayout} */}
-{/*         onChange={(e) => onChangeLayout(e.target.value)} */}
-{/*       > */}
-{/*         {LAYOUTS.map((layout) => ( */}
-{/*           <option key={layout} value={layout}> */}
-{/*             {layout} */}
-{/*           </option> */}
-{/*         ))} */}
-{/*       </select> */}
-
-      {/* Preview — logs slides to console for now */}
-      {/* FUTURE: Open a full-screen preview modal or route */}
       <button onClick={onPreview}>Preview</button>
 
-      {/* Logout */}
-      <button onClick={onLogout}>Logout</button>
+      <button onClick={onSave} disabled={saveStatus === "saving"}>
+        {saveStatus === "saving"
+          ? "Saving..."
+          : saveStatus === "saved"
+            ? "Saved!"
+            : saveStatus === "error"
+              ? "Save failed"
+              : "Save"}
+      </button>
+
+      <button onClick={onGoToLayouts}>Layouts</button>
     </div>
   );
 }

--- a/frontend/src/pages/Canvas.jsx
+++ b/frontend/src/pages/Canvas.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import Toolbar from "../components/Toolbar";
 import SlidesPanel from "../components/SlidesPanel";
@@ -7,369 +7,458 @@ import PropertiesPanel from "../components/PropertiesPanel";
 import "../styles/canvas.css";
 
 // ===== Layout Definitions =====
-// Maps each layout name to its default sections
-// const LAYOUT_TEMPLATES = {
-//   single: [{ id: 1, contentType: "text", content: "" }],
-//   "two-columns": [
-//     { id: 1, contentType: "text", content: "" },
-//     { id: 2, contentType: "text", content: "" },
-//   ],
-//   "header-two-columns": [
-//     { id: 1, contentType: "text", content: "" },
-//     { id: 2, contentType: "text", content: "" },
-//     { id: 3, contentType: "text", content: "" },
-//   ],
-//   grid: [
-//     { id: 1, contentType: "text", content: "" },
-//     { id: 2, contentType: "text", content: "" },
-//     { id: 3, contentType: "text", content: "" },
-//     { id: 4, contentType: "text", content: "" },
-//   ],
-//   "right-column": [
-//     { id: 1, contentType: "text", content: "" },
-//     { id: 2, contentType: "text", content: "" },
-//     { id: 3, contentType: "text", content: "" },
-//     { id: 4, contentType: "text", content: "" },
-//   ],
-//   "bottom-row": [
-//     { id: 1, contentType: "text", content: "" },
-//     { id: 2, contentType: "text", content: "" },
-//     { id: 3, contentType: "text", content: "" },
-//     { id: 4, contentType: "text", content: "" },
-//   ],
-//   "six-section-grid": [
-//     { id: 1, contentType: "text", content: "" },
-//     { id: 2, contentType: "text", content: "" },
-//     { id: 3, contentType: "text", content: "" },
-//     { id: 4, contentType: "text", content: "" },
-//     { id: 5, contentType: "text", content: "" },
-//     { id: 6, contentType: "text", content: "" },
-//   ],
-// };
+const LAYOUT_TEMPLATES = {
+  single: [{ id: 1, contentType: "text", content: "" }],
+  "two-columns": [
+    { id: 1, contentType: "text", content: "" },
+    { id: 2, contentType: "text", content: "" },
+  ],
+  "header-two-columns": [
+    { id: 1, contentType: "text", content: "" },
+    { id: 2, contentType: "text", content: "" },
+    { id: 3, contentType: "text", content: "" },
+  ],
+  grid: [
+    { id: 1, contentType: "text", content: "" },
+    { id: 2, contentType: "text", content: "" },
+    { id: 3, contentType: "text", content: "" },
+    { id: 4, contentType: "text", content: "" },
+  ],
+  "right-column": [
+    { id: 1, contentType: "text", content: "" },
+    { id: 2, contentType: "text", content: "" },
+    { id: 3, contentType: "text", content: "" },
+    { id: 4, contentType: "text", content: "" },
+  ],
+  "bottom-row": [
+    { id: 1, contentType: "text", content: "" },
+    { id: 2, contentType: "text", content: "" },
+    { id: 3, contentType: "text", content: "" },
+    { id: 4, contentType: "text", content: "" },
+  ],
+  "six-section-grid": [
+    { id: 1, contentType: "text", content: "" },
+    { id: 2, contentType: "text", content: "" },
+    { id: 3, contentType: "text", content: "" },
+    { id: 4, contentType: "text", content: "" },
+    { id: 5, contentType: "text", content: "" },
+    { id: 6, contentType: "text", content: "" },
+  ],
+};
 
-// Helper to create a fresh slide
-// function createSlide(layout = "single") {
-//   return {
-//     layout,
-//     sections: LAYOUT_TEMPLATES[layout].map((s) => ({ ...s })),
-//   };
-// }
+// Backend grid mapping (1-indexed positions as required by backend validation)
+const TEMPLATE_GRID_MAP = {
+  single: {
+    cols: 1,
+    rows: 1,
+    slots: [{ colPos: 1, rowPos: 1, colSpan: 1, rowSpan: 1 }],
+  },
+  "two-columns": {
+    cols: 2,
+    rows: 1,
+    slots: [
+      { colPos: 1, rowPos: 1, colSpan: 1, rowSpan: 1 },
+      { colPos: 2, rowPos: 1, colSpan: 1, rowSpan: 1 },
+    ],
+  },
+  "header-two-columns": {
+    cols: 2,
+    rows: 2,
+    slots: [
+      { colPos: 1, rowPos: 1, colSpan: 2, rowSpan: 1 },
+      { colPos: 1, rowPos: 2, colSpan: 1, rowSpan: 1 },
+      { colPos: 2, rowPos: 2, colSpan: 1, rowSpan: 1 },
+    ],
+  },
+  grid: {
+    cols: 2,
+    rows: 2,
+    slots: [
+      { colPos: 1, rowPos: 1, colSpan: 1, rowSpan: 1 },
+      { colPos: 2, rowPos: 1, colSpan: 1, rowSpan: 1 },
+      { colPos: 1, rowPos: 2, colSpan: 1, rowSpan: 1 },
+      { colPos: 2, rowPos: 2, colSpan: 1, rowSpan: 1 },
+    ],
+  },
+  "right-column": {
+    cols: 2,
+    rows: 3,
+    slots: [
+      { colPos: 1, rowPos: 1, colSpan: 1, rowSpan: 3 },
+      { colPos: 2, rowPos: 1, colSpan: 1, rowSpan: 1 },
+      { colPos: 2, rowPos: 2, colSpan: 1, rowSpan: 1 },
+      { colPos: 2, rowPos: 3, colSpan: 1, rowSpan: 1 },
+    ],
+  },
+  "bottom-row": {
+    cols: 3,
+    rows: 2,
+    slots: [
+      { colPos: 1, rowPos: 1, colSpan: 3, rowSpan: 1 },
+      { colPos: 1, rowPos: 2, colSpan: 1, rowSpan: 1 },
+      { colPos: 2, rowPos: 2, colSpan: 1, rowSpan: 1 },
+      { colPos: 3, rowPos: 2, colSpan: 1, rowSpan: 1 },
+    ],
+  },
+  "six-section-grid": {
+    cols: 3,
+    rows: 3,
+    slots: [
+      { colPos: 1, rowPos: 1, colSpan: 2, rowSpan: 2 },
+      { colPos: 3, rowPos: 1, colSpan: 1, rowSpan: 1 },
+      { colPos: 3, rowPos: 2, colSpan: 1, rowSpan: 1 },
+      { colPos: 1, rowPos: 3, colSpan: 1, rowSpan: 1 },
+      { colPos: 2, rowPos: 3, colSpan: 1, rowSpan: 1 },
+      { colPos: 3, rowPos: 3, colSpan: 1, rowSpan: 1 },
+    ],
+  },
+};
 
-// ===== Canvas Page — Main Editor =====
-function Canvas() {
-    const [layout, setLayout] = useState({
-        name:"Main Layout",
-        cols: 1,
-        rows: 1,
-        id: null,
-        slots: [
-            {id: null, colPos: 1, rowPos: 1, colSpan: 1, rowSpan: 1, zIndex: 1}
-        ]
+function detectTemplate(cols, rows, slotCount) {
+  if (cols === 1 && rows === 1) return "single";
+  if (cols === 2 && rows === 1) return "two-columns";
+  if (cols === 2 && rows === 2 && slotCount === 3) return "header-two-columns";
+  if (cols === 2 && rows === 2) return "grid";
+  if (cols === 2 && rows === 3) return "right-column";
+  if (cols === 3 && rows === 2) return "bottom-row";
+  if (cols === 3 && rows === 3) return "six-section-grid";
+  return "single";
+}
 
-      });
-
-  const [searchParams] = useSearchParams();
-  const layoutId = searchParams.get("layoutId");
-  const [loading, setLoading] = useState(true);
-  const hasFetched = useRef(false);
-
-
-  const handleSave = async () => {
-    try {
-    console.log(JSON.stringify(layout))
-     const res = await fetch(`/api/layouts/${layoutId}/slots`, {
-       method: "POST",
-       headers: {
-         "Content-Type": "application/json",
-       },
-       body: JSON.stringify(layout),
-     });
-
-     if (!res.ok) {
-       throw new Error("Failed to save slot");
-     }
-
-     const data = await res.json();
-     return data;
-    } catch (err) {
-     console.error("Slot save error:", err);
-     return null;
-    }
+function parseLayoutName(name) {
+  if (!name) return { displayName: "", template: null };
+  const idx = name.lastIndexOf("::");
+  if (idx === -1) return { displayName: name, template: null };
+  return {
+    displayName: name.substring(0, idx),
+    template: name.substring(idx + 2),
   };
+}
 
-  useEffect(() => {
-      if (hasFetched.current) return;
-      if (!layoutId) return;
+// Layout.name is VARCHAR(50) — keep the encoded name within that limit
+function encodeLayoutName(displayName, template) {
+  const suffix = `::${template}`;
+  const maxDisplayLen = 50 - suffix.length;
+  const truncated =
+    displayName.length > maxDisplayLen
+      ? displayName.substring(0, maxDisplayLen)
+      : displayName;
+  return `${truncated}${suffix}`;
+}
 
-      hasFetched.current = true;
+function createSlide(layout = "single") {
+  return {
+    layout,
+    sections: LAYOUT_TEMPLATES[layout].map((s) => ({ ...s })),
+  };
+}
 
-      fetch(`/api/layouts/${layoutId}`)
-        .then(r => r.json())
-        .then(res => {
-          const data = res.data || {};
-
-          setLayout(prev => ({
-            ...prev,
-            id: data.id ?? prev.id,
-            cols: data.cols ?? prev.cols,
-            rows: data.rows ?? prev.rows,
-            slots: Array.isArray(data.slots) && data.slots.length
-              ? data.slots
-              : buildSlots(data.rows ?? prev.rows, data.cols ?? prev.cols),
-          }));
-        })
-        .finally(() => setLoading(false));
-    }, [layoutId]);
-
-    const buildSlots = (rows, cols, prevSlots = []) => {
-      const map = new Map();
-      prevSlots.forEach((s) => {
-        map.set(`${s.rowPos}-${s.colPos}`, s);
-      });
-
-      const slots = [];
-
-      for (let r = 1; r <= rows; r++) {
-        for (let c = 1; c <= cols; c++) {
-          const key = `${r}-${c}`;
-          slots.push(
-            map.get(key) || {
-              id: null,
-              rowPos: r,
-              colPos: c,
-              rowSpan: 1,
-              colSpan: 1,
-              zIndex: 1,
-              contentType: "text",
-              content: ""
-            }
-          );
-        }
-      }
-
-      return slots;
-    };
-  const addRow = useCallback(() => {
-      setLayout((prev) => {
-        const rows = prev.rows + 1;
-        return {
-          ...prev,
-          rows,
-          slots: buildSlots(rows, prev.cols, prev.slots),
-        };
-      });
-
-  },[]);
-
-  const removeRow = useCallback(() => {
-      setLayout((prev) => {
-        if (prev.rows <= 1) return prev;
-
-        const rows = prev.rows - 1;
-
-        return {
-          ...prev,
-          rows,
-          slots: buildSlots(rows, prev.cols, prev.slots),
-        };
-      });
-  },[]);
-
-
-  const addColumn = useCallback(() => {
-      setLayout((prev) => {
-        const cols = prev.cols + 1;
-
-        return {
-          ...prev,
-          cols,
-          slots: buildSlots(prev.rows, cols, prev.slots),
-        };
-      });
-  },[]);
-
-
-  const removeColumn = useCallback(() => {
-      setLayout((prev) => {
-        if (prev.cols <= 1) return prev;
-
-        const cols = prev.cols - 1;
-
-        return {
-          ...prev,
-          cols,
-          slots: buildSlots(prev.rows, cols, prev.slots),
-        };
-      });
-
-  },[]);
-
-  useEffect(() => {
-    console.log(layout);
-  }, [layout]);
-
+function Canvas() {
   const navigate = useNavigate();
-//
-//   // FUTURE: Load slides from API on mount
-//   // useEffect(() => { fetch("/api/slides").then(...) }, []);
-//   const [slides, setSlides] = useState([createSlide("two-columns")]);
+  const [searchParams] = useSearchParams();
+  const layoutIdParam = searchParams.get("layoutId");
+
+  const [slides, setSlides] = useState([createSlide("two-columns")]);
   const [currentSlideIndex, setCurrentSlideIndex] = useState(0);
   const [selectedSectionId, setSelectedSectionId] = useState(null);
-//
-//   const currentSlide = slides[currentSlideIndex];
-//
-//   // ===== Slide Operations =====
+  const [activeLayoutId, setActiveLayoutId] = useState(layoutIdParam);
+  const [layoutDisplayName, setLayoutDisplayName] = useState("");
+  const [savedSlotIds, setSavedSlotIds] = useState([]);
+  const [savedModuleIds, setSavedModuleIds] = useState([]);
+  const [saveStatus, setSaveStatus] = useState(null);
+
+  const currentSlide = slides[currentSlideIndex];
+
+  useEffect(() => {
+    function loadLayout(layout) {
+      const { displayName, template: savedTemplate } = parseLayoutName(
+        layout.name
+      );
+      setLayoutDisplayName(displayName || layout.name);
+      setActiveLayoutId(layout.id);
+
+      const slots = layout.slots ?? [];
+      const sortedSlots = [...slots].sort(
+        (a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0)
+      );
+      const slotCount = sortedSlots.length;
+      const template =
+        savedTemplate && LAYOUT_TEMPLATES[savedTemplate]
+          ? savedTemplate
+          : detectTemplate(layout.cols, layout.rows, slotCount);
+
+      // Rebuild sections from template, restoring saved content from module.config
+      const templateSections = LAYOUT_TEMPLATES[template];
+      const sections = templateSections.map((defaultSection, i) => {
+        const slot = sortedSlots[i];
+        const config = slot?.module?.config;
+        if (config && (config.contentType || config.content)) {
+          return {
+            ...defaultSection,
+            contentType: config.contentType || defaultSection.contentType,
+            content: config.content || "",
+          };
+        }
+        return { ...defaultSection };
+      });
+
+      setSlides([{ layout: template, sections }]);
+      setCurrentSlideIndex(0);
+      setSelectedSectionId(null);
+      setSavedSlotIds(sortedSlots.map((s) => s.id));
+      setSavedModuleIds(sortedSlots.map((s) => s.module?.id ?? null));
+    }
+
+    if (layoutIdParam) {
+      fetch(`/api/layouts/${layoutIdParam}`)
+        .then((r) => r.json())
+        .then((res) => {
+          if (res.data) loadLayout(res.data);
+        })
+        .catch((err) => console.error("Failed to load layout:", err));
+    } else {
+      fetch("/api/layouts")
+        .then((r) => r.json())
+        .then((res) => {
+          const layouts = res.data ?? [];
+          if (layouts.length > 0) loadLayout(layouts[layouts.length - 1]);
+        })
+        .catch((err) => console.error("Failed to load layouts:", err));
+    }
+  }, [layoutIdParam]);
+
+  // ===== Save — persist modules (content) then layout (structure) =====
+  const handleSave = useCallback(async () => {
+    if (!activeLayoutId) return;
+    setSaveStatus("saving");
+
+    try {
+      const slide = slides[currentSlideIndex] || slides[0];
+      const gridInfo =
+        TEMPLATE_GRID_MAP[slide.layout] || TEMPLATE_GRID_MAP.single;
+
+      // Step 1: create or update a Module for each section
+      const moduleIds = await Promise.all(
+        slide.sections.map(async (section, i) => {
+          const moduleData = {
+            name: `section-${i + 1}`,
+            type: "CLOCK",
+            config: {
+              contentType: section.contentType,
+              content: section.content,
+            },
+            adCollection: null,
+          };
+
+          const existingId = savedModuleIds[i];
+          if (existingId) {
+            const res = await fetch(`/api/modules/${existingId}`, {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(moduleData),
+            });
+            if (!res.ok) throw new Error(`Module update failed for section ${i}`);
+            const data = await res.json();
+            return data.data?.id ?? existingId;
+          }
+
+          const res = await fetch("/api/modules", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(moduleData),
+          });
+          if (!res.ok) throw new Error(`Module creation failed for section ${i}`);
+          const data = await res.json();
+          return data.data?.id;
+        })
+      );
+
+      // Step 2: save the layout with slot positions + module references
+      const slots = gridInfo.slots.map((slotPos, i) => ({
+        id: i < savedSlotIds.length ? savedSlotIds[i] : null,
+        moduleId: moduleIds[i] ?? null,
+        colPos: slotPos.colPos,
+        rowPos: slotPos.rowPos,
+        colSpan: slotPos.colSpan,
+        rowSpan: slotPos.rowSpan,
+        zIndex: i + 1,
+      }));
+
+      const body = {
+        name: encodeLayoutName(
+          layoutDisplayName || slide.layout,
+          slide.layout
+        ),
+        cols: gridInfo.cols,
+        rows: gridInfo.rows,
+        slots,
+      };
+
+      const layoutRes = await fetch(`/api/layouts/${activeLayoutId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!layoutRes.ok) throw new Error("Layout save failed");
+      const layoutData = await layoutRes.json();
+
+      // Update tracked IDs from the response
+      if (layoutData.data?.slots) {
+        const returnedSlots = [...layoutData.data.slots].sort(
+          (a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0)
+        );
+        setSavedSlotIds(returnedSlots.map((s) => s.id));
+        setSavedModuleIds(returnedSlots.map((s) => s.module?.id ?? null));
+      }
+
+      setSaveStatus("saved");
+      setTimeout(() => setSaveStatus(null), 2000);
+    } catch (err) {
+      console.error("Save error:", err);
+      setSaveStatus("error");
+      setTimeout(() => setSaveStatus(null), 3000);
+    }
+  }, [
+    activeLayoutId,
+    slides,
+    currentSlideIndex,
+    layoutDisplayName,
+    savedSlotIds,
+    savedModuleIds,
+  ]);
+
+  // ===== Slide Operations =====
   const addSlide = useCallback(() => {
-//     setSlides((prev) => [...prev, createSlide("single")]);
-//     setCurrentSlideIndex(slides.length);
-//     setSelectedSectionId(null);
-  }, []);
-//
+    setSlides((prev) => [...prev, createSlide("single")]);
+    setCurrentSlideIndex(slides.length);
+    setSelectedSectionId(null);
+  }, [slides.length]);
+
   const switchSlide = useCallback((index) => {
-//     setCurrentSlideIndex(index);
-//     setSelectedSectionId(null);
+    setCurrentSlideIndex(index);
+    setSelectedSectionId(null);
   }, []);
-//
+
   const deleteSlide = useCallback(
     (index) => {
-//       if (slides.length <= 1) return;
-//       setSlides((prev) => prev.filter((_, i) => i !== index));
-//       setCurrentSlideIndex((prev) => {
-//         if (prev >= slides.length - 1) return Math.max(0, slides.length - 2);
-//         if (index <= prev) return Math.max(0, prev - 1);
-//         return prev;
-//       });
-//       setSelectedSectionId(null);
+      if (slides.length <= 1) return;
+      setSlides((prev) => prev.filter((_, i) => i !== index));
+      setCurrentSlideIndex((prev) => {
+        if (prev >= slides.length - 1) return Math.max(0, slides.length - 2);
+        if (index <= prev) return Math.max(0, prev - 1);
+        return prev;
+      });
+      setSelectedSectionId(null);
     },
-    []
+    [slides.length]
   );
-//
-//   // ===== Layout Change =====
+
+  // ===== Layout Change =====
   const changeLayout = useCallback(
     (layout) => {
-//       setSlides((prev) =>
-//         prev.map((slide, i) =>
-//           i === currentSlideIndex
-//             ? {
-//                 ...slide,
-//                 layout,
-//                 sections: LAYOUT_TEMPLATES[layout].map((s) => ({ ...s })),
-//               }
-//             : slide
-//         )
-//       );
-//       setSelectedSectionId(null);
+      setSlides((prev) =>
+        prev.map((slide, i) =>
+          i === currentSlideIndex
+            ? {
+                ...slide,
+                layout,
+                sections: LAYOUT_TEMPLATES[layout].map((s) => ({ ...s })),
+              }
+            : slide
+        )
+      );
+      setSelectedSectionId(null);
     },
-    []
+    [currentSlideIndex]
   );
-//
-//   // ===== Section Selection =====
+
+  // ===== Section Selection =====
   const selectSection = useCallback((sectionId) => {
     setSelectedSectionId(sectionId);
   }, []);
-//
-//   // ===== Section Update (from PropertiesPanel) =====
 
-    const updateSection = useCallback((sectionKey, changes) => {
-      setLayout((prev) => ({
-        ...prev,
-        slots: prev.slots.map((slot) => {
-          const key = `${slot.rowPos}-${slot.colPos}`;
-
-          if (key === sectionKey) {
-            return {
-              ...slot,
-              ...changes,
-            };
-          }
-
-          return slot;
-        }),
-      }));
-    }, []);
-
-//
-//   // ===== Slide Reorder =====
-  const reorderSlides = useCallback(
-    (fromIndex, toIndex) => {
-//       setSlides((prev) => {
-//         const updated = [...prev];
-//         const [moved] = updated.splice(fromIndex, 1);
-//         updated.splice(toIndex, 0, moved);
-//         return updated;
-//       });
-//       // Adjust currentSlideIndex to follow the moved slide
-//       setCurrentSlideIndex((prev) => {
-//         if (prev === fromIndex) return toIndex;
-//         if (fromIndex < prev && toIndex >= prev) return prev - 1;
-//         if (fromIndex > prev && toIndex <= prev) return prev + 1;
-//         return prev;
-//       });
+  // ===== Section Update (from PropertiesPanel) =====
+  const updateSection = useCallback(
+    (sectionId, changes) => {
+      setSlides((prev) =>
+        prev.map((slide, i) =>
+          i === currentSlideIndex
+            ? {
+                ...slide,
+                sections: slide.sections.map((sec) =>
+                  sec.id === sectionId ? { ...sec, ...changes } : sec
+                ),
+              }
+            : slide
+        )
+      );
     },
-    []
+    [currentSlideIndex]
   );
-//
-//   // ===== Preview (stub) =====
-  const handlePreview = useCallback(() => {
-//     console.log("Preview slides:", JSON.stringify(slides, null, 2));
-  }, []);
-//
-//   // Get currently selected section data for the properties panel
-  const getSlotKey = (s) => s.id ?? `${s.rowPos}-${s.colPos}`;
 
-  const selectedSection = layout.slots.find(
-    (s) => getSlotKey(s) === selectedSectionId
-  );
+  // ===== Slide Reorder =====
+  const reorderSlides = useCallback((fromIndex, toIndex) => {
+    setSlides((prev) => {
+      const updated = [...prev];
+      const [moved] = updated.splice(fromIndex, 1);
+      updated.splice(toIndex, 0, moved);
+      return updated;
+    });
+    setCurrentSlideIndex((prev) => {
+      if (prev === fromIndex) return toIndex;
+      if (fromIndex < prev && toIndex >= prev) return prev - 1;
+      if (fromIndex > prev && toIndex <= prev) return prev + 1;
+      return prev;
+    });
+  }, []);
+
+  // ===== Preview (stub) =====
+  const handlePreview = useCallback(() => {
+    console.log("Preview slides:", JSON.stringify(slides, null, 2));
+  }, [slides]);
+
+  const selectedSection = currentSlide
+    ? currentSlide.sections.find((s) => s.id === selectedSectionId)
+    : null;
 
   return (
     <div className="editor">
-      {/* Top Toolbar */}
       <Toolbar
-        currentLayout={layout}
+        currentLayout={currentSlide?.layout}
         onAddSlide={addSlide}
         onChangeLayout={changeLayout}
         onPreview={handlePreview}
+        onGoToLayouts={() => navigate("/layouts")}
         onSave={handleSave}
-        onLogout={() => navigate("/")}
-
-
-        onAddRow={addRow}
-        onAddColumn={addColumn}
-
-        onRemoveRow={removeRow}
-        onRemoveColumn={removeColumn}
+        saveStatus={saveStatus}
       />
 
       <div className="editor-body">
-        {/* Left — Slides Panel */}
-{/*         <SlidesPanel */}
-{/*           slides={layout} */}
-{/*           currentSlideIndex={1} */}
-{/*           onSwitchSlide={switchSlide} */}
-{/*           onAddSlide={addSlide} */}
-{/*           onDeleteSlide={deleteSlide} */}
-{/*           onReorderSlides={reorderSlides} */}
-{/*         /> */}
+        <SlidesPanel
+          slides={slides}
+          currentSlideIndex={currentSlideIndex}
+          onSwitchSlide={switchSlide}
+          onAddSlide={addSlide}
+          onDeleteSlide={deleteSlide}
+          onReorderSlides={reorderSlides}
+        />
 
-        {/* Center — Canvas */}
         <div className="canvas-area">
           <div className="canvas-frame">
-            <LayoutRenderer
-                layout={layout}
-                slots={layout.slots}
+            {currentSlide && (
+              <LayoutRenderer
+                layout={currentSlide.layout}
+                sections={currentSlide.sections}
                 selectedSectionId={selectedSectionId}
                 onSelectSection={selectSection}
-                rows={layout.rows}
-                cols={layout.cols}
               />
+            )}
           </div>
         </div>
 
-        {/* Right — Properties Panel */}
         <PropertiesPanel
           section={selectedSection}
           onUpdate={updateSection}
-          sectionKey={selectedSectionId}
         />
       </div>
     </div>

--- a/frontend/src/pages/Canvas.jsx
+++ b/frontend/src/pages/Canvas.jsx
@@ -6,6 +6,8 @@ import LayoutRenderer from "../components/LayoutRenderer";
 import PropertiesPanel from "../components/PropertiesPanel";
 import "../styles/canvas.css";
 
+const SLIDE_ROW_OFFSET = 100;
+
 // ===== Layout Definitions =====
 const LAYOUT_TEMPLATES = {
   single: [{ id: 1, contentType: "text", content: "" }],
@@ -125,27 +127,6 @@ function detectTemplate(cols, rows, slotCount) {
   return "single";
 }
 
-function parseLayoutName(name) {
-  if (!name) return { displayName: "", template: null };
-  const idx = name.lastIndexOf("::");
-  if (idx === -1) return { displayName: name, template: null };
-  return {
-    displayName: name.substring(0, idx),
-    template: name.substring(idx + 2),
-  };
-}
-
-// Layout.name is VARCHAR(50) — keep the encoded name within that limit
-function encodeLayoutName(displayName, template) {
-  const suffix = `::${template}`;
-  const maxDisplayLen = 50 - suffix.length;
-  const truncated =
-    displayName.length > maxDisplayLen
-      ? displayName.substring(0, maxDisplayLen)
-      : displayName;
-  return `${truncated}${suffix}`;
-}
-
 function createSlide(layout = "single") {
   return {
     layout,
@@ -161,59 +142,92 @@ function Canvas() {
   const [slides, setSlides] = useState([createSlide("two-columns")]);
   const [currentSlideIndex, setCurrentSlideIndex] = useState(0);
   const [selectedSectionId, setSelectedSectionId] = useState(null);
-  const [activeLayoutId, setActiveLayoutId] = useState(layoutIdParam);
   const [layoutDisplayName, setLayoutDisplayName] = useState("");
-  const [savedSlotIds, setSavedSlotIds] = useState([]);
-  const [savedModuleIds, setSavedModuleIds] = useState([]);
   const [saveStatus, setSaveStatus] = useState(null);
+
+  const [savedLayoutId, setSavedLayoutId] = useState(null);
+  const [savedModuleIds, setSavedModuleIds] = useState([]);
 
   const currentSlide = slides[currentSlideIndex];
 
   useEffect(() => {
-    function loadLayout(layout) {
-      const { displayName, template: savedTemplate } = parseLayoutName(
-        layout.name
-      );
-      setLayoutDisplayName(displayName || layout.name);
-      setActiveLayoutId(layout.id);
+    function loadFromLayout(layout) {
+      const rawName = layout.name || "";
+      const cleanName = rawName.includes("::")
+        ? rawName
+            .substring(0, rawName.lastIndexOf("::"))
+            .replace(/\[\d+\]$/, "")
+        : rawName;
+      setLayoutDisplayName(cleanName);
+      setSavedLayoutId(layout.id);
 
       const slots = layout.slots ?? [];
-      const sortedSlots = [...slots].sort(
-        (a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0)
-      );
-      const slotCount = sortedSlots.length;
-      const template =
-        savedTemplate && LAYOUT_TEMPLATES[savedTemplate]
-          ? savedTemplate
-          : detectTemplate(layout.cols, layout.rows, slotCount);
+      if (slots.length === 0) {
+        setSlides([createSlide("two-columns")]);
+        setCurrentSlideIndex(0);
+        setSavedModuleIds([]);
+        console.log("Loaded empty layout, showing default slide");
+        return;
+      }
 
-      // Rebuild sections from template, restoring saved content from module.config
-      const templateSections = LAYOUT_TEMPLATES[template];
-      const sections = templateSections.map((defaultSection, i) => {
-        const slot = sortedSlots[i];
-        const config = slot?.module?.config;
-        if (config && (config.contentType || config.content)) {
-          return {
-            ...defaultSection,
-            contentType: config.contentType || defaultSection.contentType,
-            content: config.content || "",
-          };
+      const slideGroups = new Map();
+      for (const slot of slots) {
+        const slideIdx = Math.floor((slot.rowPos - 1) / SLIDE_ROW_OFFSET);
+        if (!slideGroups.has(slideIdx)) slideGroups.set(slideIdx, []);
+        slideGroups.get(slideIdx).push(slot);
+      }
+
+      const sortedIndices = [...slideGroups.keys()].sort((a, b) => a - b);
+      const newSlides = [];
+      const newModuleIds = [];
+
+      for (const slideIdx of sortedIndices) {
+        const slideSlots = slideGroups.get(slideIdx);
+        slideSlots.sort((a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0));
+
+        const firstConfig = slideSlots[0]?.module?.config;
+        let template = firstConfig?.template;
+        if (!template || !LAYOUT_TEMPLATES[template]) {
+          template = detectTemplate(
+            layout.cols,
+            layout.rows,
+            slideSlots.length
+          );
         }
-        return { ...defaultSection };
-      });
 
-      setSlides([{ layout: template, sections }]);
+        const templateSections = LAYOUT_TEMPLATES[template];
+        const sections = templateSections.map((defaultSection, i) => {
+          const slot = slideSlots[i];
+          const config = slot?.module?.config;
+          if (config && (config.contentType || config.content)) {
+            return {
+              ...defaultSection,
+              contentType: config.contentType || defaultSection.contentType,
+              content: config.content || "",
+            };
+          }
+          return { ...defaultSection };
+        });
+
+        newSlides.push({ layout: template, sections });
+        newModuleIds.push(slideSlots.map((s) => s.module?.id ?? null));
+      }
+
+      setSlides(newSlides);
       setCurrentSlideIndex(0);
       setSelectedSectionId(null);
-      setSavedSlotIds(sortedSlots.map((s) => s.id));
-      setSavedModuleIds(sortedSlots.map((s) => s.module?.id ?? null));
+      setSavedModuleIds(newModuleIds);
+
+      console.log(
+        `Loaded ${newSlides.length} slide(s) from layout ${layout.id}`
+      );
     }
 
     if (layoutIdParam) {
       fetch(`/api/layouts/${layoutIdParam}`)
         .then((r) => r.json())
         .then((res) => {
-          if (res.data) loadLayout(res.data);
+          if (res.data) loadFromLayout(res.data);
         })
         .catch((err) => console.error("Failed to load layout:", err));
     } else {
@@ -221,96 +235,132 @@ function Canvas() {
         .then((r) => r.json())
         .then((res) => {
           const layouts = res.data ?? [];
-          if (layouts.length > 0) loadLayout(layouts[layouts.length - 1]);
+          if (layouts.length > 1) {
+            console.warn(
+              `Found ${layouts.length} layouts. IDs: ${layouts.map((l) => l.id).join(", ")}. ` +
+                `These may include orphaned layouts from previous saves. Loading the most recent one (ID: ${layouts[layouts.length - 1].id}).`
+            );
+          }
+          if (layouts.length > 0) loadFromLayout(layouts[layouts.length - 1]);
         })
         .catch((err) => console.error("Failed to load layouts:", err));
     }
   }, [layoutIdParam]);
 
-  // ===== Save — persist modules (content) then layout (structure) =====
+  // ===== Save — persist all slides into one layout =====
   const handleSave = useCallback(async () => {
-    if (!activeLayoutId) return;
     setSaveStatus("saving");
 
     try {
-      const slide = slides[currentSlideIndex] || slides[0];
-      const gridInfo =
-        TEMPLATE_GRID_MAP[slide.layout] || TEMPLATE_GRID_MAP.single;
+      const newModuleIds = [];
+      for (let slideIdx = 0; slideIdx < slides.length; slideIdx++) {
+        const slide = slides[slideIdx];
+        const existingModules = savedModuleIds[slideIdx] || [];
+        const slideModuleIds = await Promise.all(
+          slide.sections.map(async (section, i) => {
+            const moduleData = {
+              name: `slide-${slideIdx}-section-${i + 1}`,
+              type: "CLOCK",
+              config: {
+                slideIndex: slideIdx,
+                template: slide.layout,
+                contentType: section.contentType,
+                content: section.content,
+              },
+              adCollection: null,
+            };
 
-      // Step 1: create or update a Module for each section
-      const moduleIds = await Promise.all(
-        slide.sections.map(async (section, i) => {
-          const moduleData = {
-            name: `section-${i + 1}`,
-            type: "CLOCK",
-            config: {
-              contentType: section.contentType,
-              content: section.content,
-            },
-            adCollection: null,
-          };
+            const existingId = existingModules[i];
+            if (existingId) {
+              const res = await fetch(`/api/modules/${existingId}`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(moduleData),
+              });
+              if (!res.ok)
+                throw new Error(
+                  `Module update failed for slide ${slideIdx}, section ${i}`
+                );
+              const data = await res.json();
+              return data.data?.id ?? existingId;
+            }
 
-          const existingId = savedModuleIds[i];
-          if (existingId) {
-            const res = await fetch(`/api/modules/${existingId}`, {
-              method: "PUT",
+            const res = await fetch("/api/modules", {
+              method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify(moduleData),
             });
-            if (!res.ok) throw new Error(`Module update failed for section ${i}`);
+            if (!res.ok)
+              throw new Error(
+                `Module creation failed for slide ${slideIdx}, section ${i}`
+              );
             const data = await res.json();
-            return data.data?.id ?? existingId;
-          }
+            return data.data?.id;
+          })
+        );
+        newModuleIds.push(slideModuleIds);
+      }
 
-          const res = await fetch("/api/modules", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(moduleData),
+      if (savedLayoutId) {
+        await fetch(`/api/layouts/${savedLayoutId}/slots/all`, {
+          method: "DELETE",
+        });
+      }
+
+      const allSlots = [];
+      for (let slideIdx = 0; slideIdx < slides.length; slideIdx++) {
+        const slide = slides[slideIdx];
+        const gridInfo =
+          TEMPLATE_GRID_MAP[slide.layout] || TEMPLATE_GRID_MAP.single;
+        gridInfo.slots.forEach((slotPos, i) => {
+          allSlots.push({
+            moduleId: newModuleIds[slideIdx][i] ?? null,
+            colPos: slotPos.colPos,
+            rowPos: slideIdx * SLIDE_ROW_OFFSET + slotPos.rowPos,
+            colSpan: slotPos.colSpan,
+            rowSpan: slotPos.rowSpan,
+            zIndex: slideIdx * SLIDE_ROW_OFFSET + i + 1,
           });
-          if (!res.ok) throw new Error(`Module creation failed for section ${i}`);
-          const data = await res.json();
-          return data.data?.id;
-        })
-      );
+        });
+      }
 
-      // Step 2: save the layout with slot positions + module references
-      const slots = gridInfo.slots.map((slotPos, i) => ({
-        id: i < savedSlotIds.length ? savedSlotIds[i] : null,
-        moduleId: moduleIds[i] ?? null,
-        colPos: slotPos.colPos,
-        rowPos: slotPos.rowPos,
-        colSpan: slotPos.colSpan,
-        rowSpan: slotPos.rowSpan,
-        zIndex: i + 1,
-      }));
-
-      const body = {
-        name: encodeLayoutName(
-          layoutDisplayName || slide.layout,
-          slide.layout
-        ),
-        cols: gridInfo.cols,
-        rows: gridInfo.rows,
-        slots,
+      const firstGrid =
+        TEMPLATE_GRID_MAP[slides[0].layout] || TEMPLATE_GRID_MAP.single;
+      const layoutBody = {
+        name: layoutDisplayName || "Canvas",
+        cols: firstGrid.cols,
+        rows: firstGrid.rows,
+        slots: allSlots,
       };
 
-      const layoutRes = await fetch(`/api/layouts/${activeLayoutId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
+      console.log(
+        `Save payload: ${slides.length} slide(s), ${allSlots.length} total slots`,
+        layoutBody
+      );
+
+      let layoutRes;
+      if (savedLayoutId) {
+        layoutRes = await fetch(`/api/layouts/${savedLayoutId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(layoutBody),
+        });
+      } else {
+        layoutRes = await fetch("/api/layouts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(layoutBody),
+        });
+      }
       if (!layoutRes.ok) throw new Error("Layout save failed");
       const layoutData = await layoutRes.json();
 
-      // Update tracked IDs from the response
-      if (layoutData.data?.slots) {
-        const returnedSlots = [...layoutData.data.slots].sort(
-          (a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0)
-        );
-        setSavedSlotIds(returnedSlots.map((s) => s.id));
-        setSavedModuleIds(returnedSlots.map((s) => s.module?.id ?? null));
-      }
+      setSavedLayoutId(layoutData.data?.id);
+      setSavedModuleIds(newModuleIds);
 
+      console.log(
+        `Saved ${slides.length} slide(s) with ${allSlots.length} total slots to layout ${layoutData.data?.id}`
+      );
       setSaveStatus("saved");
       setTimeout(() => setSaveStatus(null), 2000);
     } catch (err) {
@@ -318,14 +368,7 @@ function Canvas() {
       setSaveStatus("error");
       setTimeout(() => setSaveStatus(null), 3000);
     }
-  }, [
-    activeLayoutId,
-    slides,
-    currentSlideIndex,
-    layoutDisplayName,
-    savedSlotIds,
-    savedModuleIds,
-  ]);
+  }, [slides, layoutDisplayName, savedLayoutId, savedModuleIds]);
 
   // ===== Slide Operations =====
   const addSlide = useCallback(() => {
@@ -343,6 +386,7 @@ function Canvas() {
     (index) => {
       if (slides.length <= 1) return;
       setSlides((prev) => prev.filter((_, i) => i !== index));
+      setSavedModuleIds((prev) => prev.filter((_, i) => i !== index));
       setCurrentSlideIndex((prev) => {
         if (prev >= slides.length - 1) return Math.max(0, slides.length - 2);
         if (index <= prev) return Math.max(0, prev - 1);
@@ -398,12 +442,14 @@ function Canvas() {
 
   // ===== Slide Reorder =====
   const reorderSlides = useCallback((fromIndex, toIndex) => {
-    setSlides((prev) => {
+    const reorder = (prev) => {
       const updated = [...prev];
       const [moved] = updated.splice(fromIndex, 1);
       updated.splice(toIndex, 0, moved);
       return updated;
-    });
+    };
+    setSlides(reorder);
+    setSavedModuleIds(reorder);
     setCurrentSlideIndex((prev) => {
       if (prev === fromIndex) return toIndex;
       if (fromIndex < prev && toIndex >= prev) return prev - 1;
@@ -448,9 +494,12 @@ function Canvas() {
             {currentSlide && (
               <LayoutRenderer
                 layout={currentSlide.layout}
-                sections={currentSlide.sections}
+                slots={currentSlide.sections}
                 selectedSectionId={selectedSectionId}
                 onSelectSection={selectSection}
+                rows={TEMPLATE_GRID_MAP[currentSlide.layout]?.rows ?? 1}
+                cols={TEMPLATE_GRID_MAP[currentSlide.layout]?.cols ?? 1}
+                gridSlots={TEMPLATE_GRID_MAP[currentSlide.layout]?.slots ?? []}
               />
             )}
           </div>

--- a/frontend/src/pages/Layouts.jsx
+++ b/frontend/src/pages/Layouts.jsx
@@ -90,7 +90,12 @@ function Layouts() {
                 </div>
                 <div className="layouts-card-footer">
                   <div>
-                    <div className="layouts-card-name">{l.name.includes('::') ? l.name.split('::')[0] : l.name}</div>
+                    <div className="layouts-card-name">{l.name.includes('::') ? l.name.split('::')[0].replace(/\[\d+\]$/, '') : l.name}</div>
+                    {l.slots && l.slots.length > 0 && (
+                      <div style={{ fontSize: '0.7rem', color: '#888', marginTop: 2 }}>
+                        {new Set(l.slots.map(s => Math.floor((s.rowPos - 1) / 100))).size} slide(s)
+                      </div>
+                    )}
                   </div>
                   <div className="layouts-card-actions">
                     <button className="layouts-action-btn" onClick={() => navigate(`/canvas?layoutId=${l.id}`)}>

--- a/frontend/src/pages/Layouts.jsx
+++ b/frontend/src/pages/Layouts.jsx
@@ -90,7 +90,7 @@ function Layouts() {
                 </div>
                 <div className="layouts-card-footer">
                   <div>
-                    <div className="layouts-card-name">{l.name}</div>
+                    <div className="layouts-card-name">{l.name.includes('::') ? l.name.split('::')[0] : l.name}</div>
                   </div>
                   <div className="layouts-card-actions">
                     <button className="layouts-action-btn" onClick={() => navigate(`/canvas?layoutId=${l.id}`)}>


### PR DESCRIPTION
Title: Canvas save/load, module persistence, and layouts nav                                                          

Summary-

  - Canvas save/load: Full template-based save system with TEMPLATE_GRID_MAP that creates/updates Modules per section,
  then saves the layout with slot positions and module references. Content is restored on load by parsing module.config.
  - Layout name encoding: encodeLayoutName/parseLayoutName store the selected template type in the layout name
  (name::template), so reopening a layout restores the correct template. Layouts.jsx strips the :: suffix for display.
  - Toolbar overhaul: Replaced commented-out controls and row/column +/- buttons with active layout selector dropdown,
  save button with status feedback (Saving…/Saved!/Save failed), and a Layouts navigation button.
  - Slide operations restored: All slide functions (add/switch/delete/reorder) are fully wired up with SlidesPanel
  rendered in the editor.
  - Merge resolution: Resolved conflicts with origin/dev after analyzing both sides — kept the more complete
  template-based implementation over the simpler direct-grid approach which had most functionality commented out.

  Files changed

  - frontend/src/pages/Canvas.jsx — template system, module persistence, content restore
  - frontend/src/components/Toolbar.jsx — active controls, save status, layouts nav
  - frontend/src/pages/Layouts.jsx — strip ::template suffix from display name

  Test plan

  - Open canvas with an existing layout — verify sections load with saved content
  - Edit section content, click Save — verify "Saving…" → "Saved!" feedback
  - Reopen the same layout — verify content persists
  - Switch layout template via dropdown — verify sections reset
  - Click Layouts button — verify navigation to /layouts
  - On Layouts page, verify layout names display without ::template suffix
  - Add/delete/reorder slides — verify all operations wor